### PR TITLE
Corrected kwargs to use two stars

### DIFF
--- a/bpystubgen/directives.py
+++ b/bpystubgen/directives.py
@@ -271,7 +271,7 @@ class FunctionLikeDirective(APIMemberDirective, ABC):
             elems["*args"] = Argument(name="*args")
 
         if func.args.kwarg:
-            elems["**kwargs"] = Argument(name="*kwargs")
+            elems["**kwargs"] = Argument(name="**kwargs")
 
         return elems, messages
 

--- a/bpystubgen/tasks.py
+++ b/bpystubgen/tasks.py
@@ -205,7 +205,7 @@ class ModuleTask(ParserTask):
         with open(marker, "w"):
             pass
 
-        fout = FileOutput(destination_path=str(target))
+        fout = FileOutput(destination_path=str(target), encoding="utf-8")
 
         try:
             writer.write(self.doctree, fout)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -428,11 +428,11 @@ def test_parse_varargs_with_kwargs(parser: Parser, document: document):
     assert args[3].name == "frames"
     assert args[3].type == "typing.Iterable[int]"
 
-    assert args[4].name == "*kwargs"
+    assert args[4].name == "**kwargs"
     assert not args[4].type
 
     assert func.signature == "def bake_action(obj: bpy.types.Object, *args, action: bpy.types.Action, " \
-                             "frames: typing.Iterable[int], *kwargs) -> None:"
+                             "frames: typing.Iterable[int], **kwargs) -> None:"
 
 
 def test_signature():


### PR DESCRIPTION
Fix for #1 

I've changed the code to emit keyword args (kwargs) function arguments with two asterisks.
Two tests had to be changed, as they expected a single asterisk, but all other tests now pass.

I haven't managed to test the resulting stubs.